### PR TITLE
First step towards release automation

### DIFF
--- a/.github/workflows/govmomi-build.yaml
+++ b/.github/workflows/govmomi-build.yaml
@@ -1,0 +1,69 @@
+#  Copyright (c) 2021 VMware, Inc. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Build
+
+on:
+  push:
+    branches: ["main", "master"]
+
+  pull_request:
+    branches: ["main", "master"]
+
+  # also run every night
+  schedule:
+    - cron: "0 1 * * *"
+
+jobs:
+  artifacts:
+    name: Build Snapshot Release (no upload)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: GoReleaser Snapshot
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist --snapshot # snapshot will disable push/release
+      - name: Verify git clean
+        shell: bash
+        run: |
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "${{ github.repository }} up to date."
+          else
+            echo "${{ github.repository }} is dirty."
+            echo "::error:: $(git status)"
+            exit 1
+          fi
+      # make artifacts available for inspection
+      # https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts
+      - name: Archive run artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          # upload only some artifacts for introspection to keep storage size small (delete after 1d)
+          path: |
+            dist/govc_*x86_64.tar.gz
+            dist/vcsim_*x86_64.tar.gz
+            dist/checksums.txt
+          retention-days: 1

--- a/.github/workflows/govmomi-check-wip.yaml
+++ b/.github/workflows/govmomi-check-wip.yaml
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 # Perform "exit 1" if PR title starts with "WIP" to block accidental merges
-name: Check "WIP" in PR Title
+name: Check WIP
 
 on:
   pull_request:
@@ -21,7 +21,7 @@ on:
 
 jobs:
   WIP:
-    name: "Check WIP in title"
+    name: "Check WIP in PR title"
     runs-on: ubuntu-latest
     if: startsWith(github.event.pull_request.title, 'WIP')
     steps:

--- a/.github/workflows/govmomi-go-lint.yaml
+++ b/.github/workflows/govmomi-go-lint.yaml
@@ -25,7 +25,6 @@ jobs:
 
   autoformat:
     name: Auto-format and Check
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
@@ -35,6 +34,8 @@ jobs:
         include:
           - tool: goimports
             importpath: golang.org/x/tools/cmd/goimports
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Set up Go 1.15.x
@@ -82,6 +83,7 @@ jobs:
   lint:
     name: Lint Files
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Set up Go 1.15.x

--- a/.github/workflows/govmomi-go-tests.yaml
+++ b/.github/workflows/govmomi-go-tests.yaml
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-name: Build
+name: Unit Tests
 
 on:
   push:
@@ -22,19 +22,17 @@ on:
     branches: [ 'main', 'master' ]
 
 jobs:
-
-  build:
-    name: Build
+  go-tests:
+    name: Run Unit Tests
     strategy:
       matrix:
-        go-version: [ '1.15', '1.16']
-        buildOS: [ 'linux', 'darwin', 'freebsd', 'windows' ]
-        platform: [ 'ubuntu-latest']
+        go-version: ["1.15", "1.16"]
+        platform: ["ubuntu-latest"]
 
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 10
 
     steps:
-
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v2
         with:
@@ -44,14 +42,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Build govc
+      - name: Run Tests
         env:
-          GOOS: ${{ matrix.buildOS }}
-        run: |
-          make -C govc install
-
-      - name: Build vcsim
-        env:
-          GOOS: ${{ matrix.buildOS }}
-        run: |
-          make -C vcsim install
+          TIMEOUT: 5m
+          TEST_OPTS: ""
+        run: go test -mod=vendor -timeout $TIMEOUT -count 1 -race -v $TEST_OPTS ./...

--- a/.github/workflows/govmomi-govc-tests.yaml
+++ b/.github/workflows/govmomi-govc-tests.yaml
@@ -12,25 +12,26 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-name: Test
+name: govc Tests
 
 on:
   push:
-    branches: [ 'main', 'master' ]
+    branches: ["main", "master"]
 
   pull_request:
-    branches: [ 'main', 'master' ]
+    branches: ["main", "master"]
 
 jobs:
-
-  test:
-    name: Unit Tests
+  govc-tests:
+    name: Run govc Tests
     strategy:
       matrix:
-        go-version: [ '1.15', '1.16' ]
-        platform: [ 'ubuntu-latest' ]
+        go-version: ["1.15", "1.16"]
+        # tests randomly hang on ubuntu-20.04 go v1.16
+        platform: ["ubuntu-18.04"]
 
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 10
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -42,9 +43,5 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Run Tests
-        env:
-          TIMEOUT: 5m
-          GORACE: history_size=5
-          TEST_OPTS: ''
-        run: go test -timeout $TIMEOUT -race -v $TEST_OPTS ./...
+      - name: Run govc Tests
+        run: make govc-test

--- a/.github/workflows/govmomi-stale.yaml
+++ b/.github/workflows/govmomi-stale.yaml
@@ -16,33 +16,30 @@ name: Close Stale
 
 on:
   schedule:
-    - cron: '0 1 * * *' # daily
+    - cron: "0 1 * * *" # daily
 
 jobs:
-
   stale:
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
 
     steps:
-      - uses: 'actions/stale@v3'
+      - uses: "actions/stale@v3"
         with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}' # No need to setup
+          repo-token: "${{ secrets.GITHUB_TOKEN }}" # No need to setup
 
           stale-issue-message: |-
             This issue is stale because it has been open for 90 days with no
             activity. It will automatically close after 30 more days of
-            inactivity. Reopen the issue with `/reopen`. Mark the issue as
-            fresh by adding the comment `/remove-lifecycle stale`.
-          stale-issue-label: 'lifecycle/stale'
-          exempt-issue-labels: 'lifecycle/frozen'
+            inactivity. Mark as fresh by adding the comment `/remove-lifecycle stale`.
+          stale-issue-label: "lifecycle/stale"
+          exempt-issue-labels: "lifecycle/frozen"
 
           stale-pr-message: |-
             This Pull Request is stale because it has been open for 90 days with
             no activity. It will automatically close after 30 more days of
-            inactivity. Reopen with `/reopen`. Mark as fresh by adding the
-            comment `/remove-lifecycle stale`.
-          stale-pr-label: 'lifecycle/stale'
-          exempt-pr-labels: 'lifecycle/frozen'
+            inactivity. Mark as fresh by adding the comment `/remove-lifecycle stale`.
+          stale-pr-label: "lifecycle/stale"
+          exempt-pr-labels: "lifecycle/frozen"
 
           days-before-stale: 90
           days-before-close: 30

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,76 +1,82 @@
 ---
 project_name: govmomi
 builds:
-- id: govc
-  goos:
-    - linux
-    - darwin
-    - windows
-    - freebsd
-  goarch:
-    - amd64
-    - 386
-    - arm64
-    - mips64le
-  env:
-    - CGO_ENABLED=0
-  main: ./govc/main.go
-  binary: govc
-  flags: -compiler gc
-  ldflags: -X github.com/vmware/govmomi/govc/flags.GitVersion={{.Version}}
-- id: vcsim
-  goos:
-    - linux
-    - darwin
-    - windows
-    - freebsd
-  goarch:
-    - amd64
-    - 386
-    - arm64
-    - mips64le
-  env:
-    - CGO_ENABLED=0
-  main: ./vcsim/main.go
-  binary: vcsim
-  flags: -compiler gc
-  ldflags: -X github.com/vmware/govmomi/vcsim/flags.GitVersion={{.Version}}
+  - id: govc
+    goos: &goos-defs
+      - linux
+      - darwin
+      - windows
+      - freebsd
+    goarch: &goarch-defs
+      - amd64
+      - arm
+      - arm64
+      - mips64le
+    env:
+      - CGO_ENABLED=0
+      - PKGPATH=github.com/vmware/govmomi/govc/flags
+    flags:
+      - "-mod=vendor"
+    main: ./govc/main.go
+    binary: govc
+    ldflags:
+      - "-X {{.Env.PKGPATH}}.BuildVersion={{.Version}} -X {{.Env.PKGPATH}}.BuildCommit={{.ShortCommit}} -X {{.Env.PKGPATH}}.BuildDate={{.Date}}"
+  - id: vcsim
+    goos: *goos-defs
+    goarch: *goarch-defs
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - "-mod=vendor"
+    main: ./vcsim/main.go
+    binary: vcsim
+    ldflags:
+      - "-X main.buildVersion={{.Version}} -X main.buildCommit={{.ShortCommit}} -X main.buildDate={{.Date}}"
 archives:
-- id: govcbuild
-  builds: ['govc']
-  name_template: 'govc_{{ .Os }}_{{ .Arch }}'
-  format: gz
-  format_overrides:
-    - goos: windows
-      format: zip
-  files:
-  - none*
-- id: vcsimbuild
-  builds: ['vcsim']
-  name_template: 'vcsim_{{ .Os }}_{{ .Arch }}'
-  format: gz
-  format_overrides:
-    - goos: windows
-      format: zip
-  files:
-  - none*
+  - id: govcbuild
+    builds:
+      - govc
+    name_template: "govc_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    replacements: &replacements
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      freebsd: FreeBSD
+      amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
+  - id: vcsimbuild
+    builds:
+      - vcsim
+    name_template: "vcsim_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    replacements: *replacements
+    format_overrides:
+      - goos: windows
+        format: zip
+snapshot:
+  name_template: "{{ .Tag }}-next"
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'
+  name_template: "checksums.txt"
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"
       - Merge pull request
       - Merge branch
 brews:
   - name: govc
     ids:
-      - govc
+      - govcbuild
     tap:
       owner: govmomi
       name: homebrew-tap
+      # TODO: create token in specified tap repo, add as secret to govmomi repo and reference in release workflow
+      # token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    # enable once we do fully automated releases
+    skip_upload: true
     commit_author:
       name: Alfred the Narwhal
       email: cna-alfred@vmware.com
@@ -83,10 +89,14 @@ brews:
       bin.install "govc"
   - name: vcsim
     ids:
-      - vcsim
+      - vcsimbuild
     tap:
       owner: govmomi
       name: homebrew-tap
+      # TODO: create token in specified tap repo, add as secret to govmomi repo and reference in release workflow
+      # token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    # enable once we do fully automated releases
+    skip_upload: true
     commit_author:
       name: Alfred the Narwhal
       email: cna-alfred@vmware.com
@@ -98,23 +108,33 @@ brews:
     install: |
       bin.install "vcsim"
 dockers:
-- image_templates: 
-  - "vmware/govc:{{ .Tag }}"
-  - "vmware/govc:v{{ .Major }}"
-  - "vmware/govc:v{{ .Major }}.{{ .Minor }}"
-  - "vmware/govc:latest"
-  goos: linux
-  goarch: amd64
-  dockerfile: Dockerfile.govc
-  binaries: 
-  - govc
-- image_templates: 
-  - "vmware/vcsim:{{ .Tag }}"
-  - "vmware/vcsim:v{{ .Major }}"
-  - "vmware/vcsim:v{{ .Major }}.{{ .Minor }}"
-  - "vmware/vcsim:latest"
-  goos: linux
-  goarch: amd64
-  dockerfile: Dockerfile.vcsim
-  binaries: 
-  - vcsim
+  - image_templates:
+      - "vmware/govc:{{ .Tag }}"
+      - "vmware/govc:{{ .ShortCommit }}"
+      - "vmware/govc:latest"
+    dockerfile: Dockerfile.govc
+    ids:
+      - govc
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.url=https://github.com/vmware/govmomi"
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "vmware/vcsim:{{ .Tag }}"
+      - "vmware/vcsim:{{ .ShortCommit }}"
+      - "vmware/vcsim:latest"
+    dockerfile: Dockerfile.vcsim
+    ids:
+      - vcsim
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.url=https://github.com/vmware/govmomi"
+      - "--platform=linux/amd64"

--- a/Dockerfile.vcsim
+++ b/Dockerfile.vcsim
@@ -43,4 +43,4 @@ EXPOSE 8989
 COPY vcsim /vcsim
 
 # Set entrypoint to application with container defaults
-ENTRYPOINT ["/vcsim", "-l", "0.0.0.0:8989"]
+CMD ["/vcsim", "-l", "0.0.0.0:8989"]

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install:
 	$(MAKE) -C vcsim install
 
 go-test:
-	GORACE=history_size=5 $(GO) test -timeout 5m -count 1 -race -v $(TEST_OPTS) ./...
+	GORACE=history_size=5 $(GO) test -mod=vendor -timeout 5m -count 1 -race -v $(TEST_OPTS) ./...
 
 govc-test: install
 	./govc/test/images/update.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build](https://github.com/vmware/govmomi/actions/workflows/govmomi-go-build.yaml/badge.svg)](https://github.com/vmware/govmomi/actions/workflows/govmomi-go-build.yaml)
-[![Test](https://github.com/vmware/govmomi/actions/workflows/govmomi-go-test.yaml/badge.svg)](https://github.com/vmware/govmomi/actions/workflows/govmomi-go-test.yaml)
+[![Build](https://github.com/vmware/govmomi/actions/workflows/govmomi-build.yaml/badge.svg)](https://github.com/vmware/govmomi/actions/workflows/govmomi-build.yaml)
+[![Tests](https://github.com/vmware/govmomi/actions/workflows/govmomi-go-tests.yaml/badge.svg)](https://github.com/vmware/govmomi/actions/workflows/govmomi-go-tests.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/vmware/govmomi)](https://goreportcard.com/report/github.com/vmware/govmomi)
 [![Latest Release](https://img.shields.io/github/release/vmware/govmomi.svg?logo=github&style=flat-square)](https://github.com/vmware/govmomi/releases/latest)
 [![Go Reference](https://pkg.go.dev/badge/github.com/vmware/govmomi.svg)](https://pkg.go.dev/github.com/vmware/govmomi)

--- a/cns/simulator/simulator.go
+++ b/cns/simulator/simulator.go
@@ -62,7 +62,7 @@ type CnsVolumeManager struct {
 
 const simulatorDiskUUID = "6000c298595bf4575739e9105b2c0c2d"
 
-func (m *CnsVolumeManager) CnsCreateVolume(ctx context.Context, req *cnstypes.CnsCreateVolume) soap.HasFault {
+func (m *CnsVolumeManager) CnsCreateVolume(ctx *simulator.Context, req *cnstypes.CnsCreateVolume) soap.HasFault {
 	task := simulator.CreateTask(m, "CnsCreateVolume", func(*simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
 		if len(req.CreateSpecs) == 0 {
 			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsVolumeCreateSpec"}
@@ -160,7 +160,7 @@ func (m *CnsVolumeManager) CnsCreateVolume(ctx context.Context, req *cnstypes.Cn
 
 	return &methods.CnsCreateVolumeBody{
 		Res: &cnstypes.CnsCreateVolumeResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
@@ -237,7 +237,7 @@ func (m *CnsVolumeManager) CnsQueryAllVolume(ctx context.Context, req *cnstypes.
 	}
 }
 
-func (m *CnsVolumeManager) CnsDeleteVolume(ctx context.Context, req *cnstypes.CnsDeleteVolume) soap.HasFault {
+func (m *CnsVolumeManager) CnsDeleteVolume(ctx *simulator.Context, req *cnstypes.CnsDeleteVolume) soap.HasFault {
 	task := simulator.CreateTask(m, "CnsDeleteVolume", func(*simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
 		operationResult := []cnstypes.BaseCnsVolumeOperationResult{}
 		for _, volumeId := range req.VolumeIds {
@@ -259,13 +259,13 @@ func (m *CnsVolumeManager) CnsDeleteVolume(ctx context.Context, req *cnstypes.Cn
 
 	return &methods.CnsDeleteVolumeBody{
 		Res: &cnstypes.CnsDeleteVolumeResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
 // CnsUpdateVolumeMetadata simulates UpdateVolumeMetadata call for simulated vc
-func (m *CnsVolumeManager) CnsUpdateVolumeMetadata(ctx context.Context, req *cnstypes.CnsUpdateVolumeMetadata) soap.HasFault {
+func (m *CnsVolumeManager) CnsUpdateVolumeMetadata(ctx *simulator.Context, req *cnstypes.CnsUpdateVolumeMetadata) soap.HasFault {
 	task := simulator.CreateTask(m, "CnsUpdateVolumeMetadata", func(*simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
 		if len(req.UpdateSpecs) == 0 {
 			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsUpdateVolumeMetadataSpec"}
@@ -291,13 +291,13 @@ func (m *CnsVolumeManager) CnsUpdateVolumeMetadata(ctx context.Context, req *cns
 	})
 	return &methods.CnsUpdateVolumeBody{
 		Res: &cnstypes.CnsUpdateVolumeMetadataResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
 // CnsAttachVolume simulates AttachVolume call for simulated vc
-func (m *CnsVolumeManager) CnsAttachVolume(ctx context.Context, req *cnstypes.CnsAttachVolume) soap.HasFault {
+func (m *CnsVolumeManager) CnsAttachVolume(ctx *simulator.Context, req *cnstypes.CnsAttachVolume) soap.HasFault {
 	task := simulator.CreateTask(m, "CnsAttachVolume", func(task *simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
 		if len(req.AttachSpecs) == 0 {
 			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsAttachVolumeSpec"}
@@ -327,13 +327,13 @@ func (m *CnsVolumeManager) CnsAttachVolume(ctx context.Context, req *cnstypes.Cn
 
 	return &methods.CnsAttachVolumeBody{
 		Res: &cnstypes.CnsAttachVolumeResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
 // CnsDetachVolume simulates DetachVolume call for simulated vc
-func (m *CnsVolumeManager) CnsDetachVolume(ctx context.Context, req *cnstypes.CnsDetachVolume) soap.HasFault {
+func (m *CnsVolumeManager) CnsDetachVolume(ctx *simulator.Context, req *cnstypes.CnsDetachVolume) soap.HasFault {
 	task := simulator.CreateTask(m, "CnsDetachVolume", func(*simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
 		if len(req.DetachSpecs) == 0 {
 			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsDetachVolumeSpec"}
@@ -358,13 +358,13 @@ func (m *CnsVolumeManager) CnsDetachVolume(ctx context.Context, req *cnstypes.Cn
 	})
 	return &methods.CnsDetachVolumeBody{
 		Res: &cnstypes.CnsDetachVolumeResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
 // CnsExtendVolume simulates ExtendVolume call for simulated vc
-func (m *CnsVolumeManager) CnsExtendVolume(ctx context.Context, req *cnstypes.CnsExtendVolume) soap.HasFault {
+func (m *CnsVolumeManager) CnsExtendVolume(ctx *simulator.Context, req *cnstypes.CnsExtendVolume) soap.HasFault {
 	task := simulator.CreateTask(m, "CnsExtendVolume", func(task *simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
 		if len(req.ExtendSpecs) == 0 {
 			return nil, &vim25types.InvalidArgument{InvalidProperty: "CnsExtendVolumeSpec"}
@@ -394,12 +394,12 @@ func (m *CnsVolumeManager) CnsExtendVolume(ctx context.Context, req *cnstypes.Cn
 
 	return &methods.CnsExtendVolumeBody{
 		Res: &cnstypes.CnsExtendVolumeResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
-func (m *CnsVolumeManager) CnsQueryVolumeInfo(ctx context.Context, req *cnstypes.CnsQueryVolumeInfo) soap.HasFault {
+func (m *CnsVolumeManager) CnsQueryVolumeInfo(ctx *simulator.Context, req *cnstypes.CnsQueryVolumeInfo) soap.HasFault {
 	task := simulator.CreateTask(m, "CnsQueryVolumeInfo", func(*simulator.Task) (vim25types.AnyType, vim25types.BaseMethodFault) {
 		operationResult := []cnstypes.BaseCnsVolumeOperationResult{}
 		for _, volumeId := range req.VolumeIds {
@@ -452,7 +452,7 @@ func (m *CnsVolumeManager) CnsQueryVolumeInfo(ctx context.Context, req *cnstypes
 
 	return &methods.CnsQueryVolumeInfoBody{
 		Res: &cnstypes.CnsQueryVolumeInfoResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,4 @@ require (
 	github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728
 )
 
-go 1.13
+go 1.14

--- a/govc/USAGE.md
+++ b/govc/USAGE.md
@@ -4827,7 +4827,9 @@ Options:
 Usage: govc version [OPTIONS]
 
 Options:
-  -require=  Require govc version >= this value
+  -require=     Require govc version >= this value
+  -l=false      Print detailed govc version information
+information
 ```
 
 ## vm.change

--- a/govc/build.sh
+++ b/govc/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+# TODO: deprecate this script as it will be superseded by goreleaser and misses additional build variables defined in
+# flags
 git_version=$(git describe --dirty)
  if [[ $git_version == *-dirty ]] ; then
   echo 'Working tree is dirty.'
@@ -12,7 +14,7 @@ PROGRAM_NAME=govc
 PROJECT_PKG="github.com/vmware/govmomi"
 PROGRAM_PKG="${PROJECT_PKG}/${PROGRAM_NAME}"
 
-export LDFLAGS="-w -X ${PROGRAM_PKG}/flags.GitVersion=${git_version}"
+export LDFLAGS="-w -X ${PROGRAM_PKG}/flags.BuildVersion=${git_version}"
 export BUILD_OS="${BUILD_OS:-darwin linux windows freebsd}"
 export BUILD_ARCH="${BUILD_ARCH:-amd64}"
 

--- a/govc/flags/client.go
+++ b/govc/flags/client.go
@@ -277,7 +277,7 @@ func (flag *ClientFlag) ConfigureTLS(sc *soap.Client) error {
 	sc.Namespace = "urn:" + flag.vimNamespace
 	sc.Version = flag.vimVersion
 
-	sc.UserAgent = fmt.Sprintf("govc/%s", Version)
+	sc.UserAgent = fmt.Sprintf("govc/%s", strings.TrimPrefix(BuildVersion, "v"))
 
 	if err := flag.SetRootCAs(sc); err != nil {
 		return err

--- a/govc/flags/version.go
+++ b/govc/flags/version.go
@@ -21,14 +21,19 @@ import (
 	"strings"
 )
 
-const Version = "0.24.0"
-
-var GitVersion string
+var (
+	BuildVersion = "v0.0.0" // govc-test requires an (arbitrary) version set
+	BuildCommit  string
+	BuildDate    string
+)
 
 type version []int
 
 func ParseVersion(s string) (version, error) {
+	// remove any trailing "v" version identifier
+	s = strings.TrimPrefix(s, "v")
 	v := make(version, 0)
+
 	ds := strings.Split(s, "-")
 	ps := strings.Split(ds[0], ".")
 	for _, p := range ps {

--- a/govc/flags/version_test.go
+++ b/govc/flags/version_test.go
@@ -16,25 +16,38 @@ limitations under the License.
 
 package flags
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestParseVersion(t *testing.T) {
-	var v version
-	var err error
-
-	v, err = ParseVersion("5.5.5.5")
-	if err != nil {
-		t.Error(err)
+	type args struct {
+		version string
 	}
-
-	if len(v) != 4 {
-		t.Errorf("Expected %d elements, got %d", 4, len(v))
+	tests := []struct {
+		name    string
+		args    args
+		want    version
+		wantErr bool
+	}{
+		{name: "5.5.5.5", args: args{version: "5.5.5.5"}, want: version{5, 5, 5, 5}, wantErr: false},
+		{name: "0.24.0", args: args{version: "0.24.0"}, want: version{0, 24, 0}, wantErr: false},
+		{name: "v0.24.0", args: args{version: "v0.24.0"}, want: version{0, 24, 0}, wantErr: false},
+		{name: "v0.24.0-next", args: args{version: "v0.24.0-next"}, want: version{0, 24, 0}, wantErr: false},
+		{name: "0.10x", args: args{version: "0.10x"}, want: nil, wantErr: true},
 	}
-
-	for i := 0; i < len(v); i++ {
-		if v[i] != 5 {
-			t.Errorf("Expected %d, got %d", 5, v[i])
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseVersion(tt.args.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseVersion() got = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/govc/test/vcsim.bats
+++ b/govc/test/vcsim.bats
@@ -20,7 +20,7 @@ load test_helper
   server=$(govc env -x GOVC_URL_HOST)
   port=$(govc env -x GOVC_URL_PORT)
 
-  docker run --rm vmware/powerclicore /usr/bin/pwsh -f - <<EOF
+  docker run --rm projects.registry.vmware.com/pez/powerclicore@sha256:09b29f69c0653f871f6d569f7c4c03c952909f68a27e9792ef2f7c8653235668 /usr/bin/pwsh -f - <<EOF
 Set-PowerCLIConfiguration -InvalidCertificateAction Ignore -confirm:\$false | Out-Null
 Connect-VIServer -Server $server -Port $port -User user -Password pass
 
@@ -301,7 +301,7 @@ docker_name() {
   assert_success
 
   ip=$(govc object.collect -s vm/$vm guest.ipAddress)
-  run docker run --rm curlimages/curl curl -f "http://$ip/vcsim.bats"
+  run curl -f "http://$ip/vcsim.bats"
   assert_success
 
   # test suspend/resume

--- a/govc/version/command.go
+++ b/govc/version/command.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strings"
 
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
@@ -29,6 +30,7 @@ type version struct {
 	*flags.EmptyFlag
 
 	require string
+	long    bool // detailed govc version output
 }
 
 func init() {
@@ -37,14 +39,11 @@ func init() {
 
 func (cmd *version) Register(ctx context.Context, f *flag.FlagSet) {
 	f.StringVar(&cmd.require, "require", "", "Require govc version >= this value")
+	f.BoolVar(&cmd.long, "l", false, "Print detailed govc version information")
 }
 
 func (cmd *version) Run(ctx context.Context, f *flag.FlagSet) error {
-	ver := flags.GitVersion
-	if ver == "" {
-		ver = flags.Version
-	}
-
+	ver := strings.TrimPrefix(flags.BuildVersion, "v")
 	if cmd.require != "" {
 		v, err := flags.ParseVersion(ver)
 		if err != nil {
@@ -61,7 +60,13 @@ func (cmd *version) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 	}
 
-	fmt.Printf("govc %s\n", ver)
+	if cmd.long {
+		fmt.Printf("Build Version: %s\n", flags.BuildVersion)
+		fmt.Printf("Build Commit: %s\n", flags.BuildCommit)
+		fmt.Printf("Build Date: %s\n", flags.BuildDate)
+	} else {
+		fmt.Printf("govc %s\n", ver)
+	}
 
 	return nil
 }

--- a/lookup/client_test.go
+++ b/lookup/client_test.go
@@ -30,7 +30,7 @@ import (
 func TestClient(t *testing.T) {
 	// lookup/simulator/simulator_test.go has the functional test..
 	// in this test we just verify requests to /lookup/sdk return 404
-	s := simulator.New(simulator.NewServiceInstance(vpx.ServiceContent, vpx.RootFolder))
+	s := simulator.New(simulator.NewServiceInstance(simulator.SpoofContext(), vpx.ServiceContent, vpx.RootFolder))
 
 	ts := s.NewServer()
 	defer ts.Close()

--- a/object/vm_guest_test.go
+++ b/object/vm_guest_test.go
@@ -61,7 +61,7 @@ func TestVirtualMachineWaitForIP(t *testing.T) {
 		wg.Wait()
 
 		wg.Add(1)
-		simulator.Map.WithLock(obj.Reference(), func() {
+		simulator.Map.WithLock(simulator.SpoofContext(), obj.Reference(), func() {
 			simulator.Map.Update(obj, []types.PropertyChange{
 				{Name: "guest.ipAddress", Val: "10.0.0.1"},
 			})

--- a/program.mk
+++ b/program.mk
@@ -24,7 +24,7 @@ TAGS += netgo
 ifeq (,$(strip $(findstring -w,$(LDFLAGS))))
 LDFLAGS += -w
 endif
-BUILD_ARGS := -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -v
+BUILD_ARGS := -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -mod=vendor -v
 
 $(PROGRAM):
 	CGO_ENABLED=0 go build -a $(BUILD_ARGS) -o $@

--- a/session/keepalive/handler_test.go
+++ b/session/keepalive/handler_test.go
@@ -121,7 +121,6 @@ func TestHandlerREST(t *testing.T) {
 
 		rc := rest.NewClient(vc)
 		rc.Transport = keepalive.NewHandlerREST(rc, time.Millisecond, i.Send)
-		err = rc.Login(ctx, simulator.DefaultLogin)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/simulator/authorization_manager_test.go
+++ b/simulator/authorization_manager_test.go
@@ -27,7 +27,7 @@ func TestAuthorizationManager(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		model := VPX()
 
-		_ = New(NewServiceInstance(model.ServiceContent, model.RootFolder)) // 2nd pass panics w/o copying RoleList
+		_ = New(NewServiceInstance(SpoofContext(), model.ServiceContent, model.RootFolder)) // 2nd pass panics w/o copying RoleList
 
 		authz := Map.Get(*vpx.ServiceContent.AuthorizationManager).(*AuthorizationManager)
 		authz.RemoveAuthorizationRole(&types.RemoveAuthorizationRole{

--- a/simulator/cluster_compute_resource.go
+++ b/simulator/cluster_compute_resource.go
@@ -36,8 +36,8 @@ type ClusterComputeResource struct {
 	ruleKey int32
 }
 
-func (c *ClusterComputeResource) RenameTask(req *types.Rename_Task) soap.HasFault {
-	return RenameTask(c, req)
+func (c *ClusterComputeResource) RenameTask(ctx *Context, req *types.Rename_Task) soap.HasFault {
+	return RenameTask(ctx, c, req)
 }
 
 type addHost struct {
@@ -67,10 +67,10 @@ func (add *addHost) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	return host.Reference(), nil
 }
 
-func (c *ClusterComputeResource) AddHostTask(add *types.AddHost_Task) soap.HasFault {
+func (c *ClusterComputeResource) AddHostTask(ctx *Context, add *types.AddHost_Task) soap.HasFault {
 	return &methods.AddHost_TaskBody{
 		Res: &types.AddHost_TaskResponse{
-			Returnval: NewTask(&addHost{c, add}).Run(),
+			Returnval: NewTask(&addHost{c, add}).Run(ctx),
 		},
 	}
 }
@@ -309,7 +309,7 @@ func (c *ClusterComputeResource) updateOverridesVmOrchestration(cfg *types.Clust
 	return nil
 }
 
-func (c *ClusterComputeResource) ReconfigureComputeResourceTask(req *types.ReconfigureComputeResource_Task) soap.HasFault {
+func (c *ClusterComputeResource) ReconfigureComputeResourceTask(ctx *Context, req *types.ReconfigureComputeResource_Task) soap.HasFault {
 	task := CreateTask(c, "reconfigureCluster", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		spec, ok := req.Spec.(*types.ClusterConfigSpecEx)
 		if !ok {
@@ -335,7 +335,7 @@ func (c *ClusterComputeResource) ReconfigureComputeResourceTask(req *types.Recon
 
 	return &methods.ReconfigureComputeResource_TaskBody{
 		Res: &types.ReconfigureComputeResource_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/simulator/cluster_compute_resource_test.go
+++ b/simulator/cluster_compute_resource_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestClusterESX(t *testing.T) {
 	content := esx.ServiceContent
-	s := New(NewServiceInstance(content, esx.RootFolder))
+	s := New(NewServiceInstance(SpoofContext(), content, esx.RootFolder))
 
 	ts := s.NewServer()
 	defer ts.Close()
@@ -55,7 +55,7 @@ func TestClusterESX(t *testing.T) {
 
 func TestClusterVC(t *testing.T) {
 	content := vpx.ServiceContent
-	s := New(NewServiceInstance(content, vpx.RootFolder))
+	s := New(NewServiceInstance(SpoofContext(), content, vpx.RootFolder))
 
 	ts := s.NewServer()
 	defer ts.Close()

--- a/simulator/custom_fields_manager.go
+++ b/simulator/custom_fields_manager.go
@@ -31,11 +31,11 @@ type CustomFieldsManager struct {
 
 // Iterates through all entities of passed field type;
 // Removes found field from their custom field properties.
-func entitiesFieldRemove(field types.CustomFieldDef) {
+func entitiesFieldRemove(ctx *Context, field types.CustomFieldDef) {
 	entities := Map.All(field.ManagedObjectType)
 	for _, e := range entities {
 		entity := e.Entity()
-		Map.WithLock(entity, func() {
+		ctx.WithLock(entity, func() {
 			aFields := entity.AvailableField
 			for i, aField := range aFields {
 				if aField.Key == field.Key {
@@ -65,11 +65,11 @@ func entitiesFieldRemove(field types.CustomFieldDef) {
 
 // Iterates through all entities of passed field type;
 // Renames found field in entity's AvailableField property.
-func entitiesFieldRename(field types.CustomFieldDef) {
+func entitiesFieldRename(ctx *Context, field types.CustomFieldDef) {
 	entities := Map.All(field.ManagedObjectType)
 	for _, e := range entities {
 		entity := e.Entity()
-		Map.WithLock(entity, func() {
+		ctx.WithLock(entity, func() {
 			aFields := entity.AvailableField
 			for i, aField := range aFields {
 				if aField.Key == field.Key {
@@ -102,7 +102,7 @@ func (c *CustomFieldsManager) findByKey(key int32) (int, *types.CustomFieldDef) 
 	return -1, nil
 }
 
-func (c *CustomFieldsManager) AddCustomFieldDef(req *types.AddCustomFieldDef) soap.HasFault {
+func (c *CustomFieldsManager) AddCustomFieldDef(ctx *Context, req *types.AddCustomFieldDef) soap.HasFault {
 	body := &methods.AddCustomFieldDefBody{}
 
 	_, field := c.findByNameType(req.Name, req.MoType)
@@ -126,7 +126,7 @@ func (c *CustomFieldsManager) AddCustomFieldDef(req *types.AddCustomFieldDef) so
 	entities := Map.All(req.MoType)
 	for _, e := range entities {
 		entity := e.Entity()
-		Map.WithLock(entity, func() {
+		ctx.WithLock(entity, func() {
 			entity.AvailableField = append(entity.AvailableField, def)
 		})
 	}
@@ -140,7 +140,7 @@ func (c *CustomFieldsManager) AddCustomFieldDef(req *types.AddCustomFieldDef) so
 	return body
 }
 
-func (c *CustomFieldsManager) RemoveCustomFieldDef(req *types.RemoveCustomFieldDef) soap.HasFault {
+func (c *CustomFieldsManager) RemoveCustomFieldDef(ctx *Context, req *types.RemoveCustomFieldDef) soap.HasFault {
 	body := &methods.RemoveCustomFieldDefBody{}
 
 	i, field := c.findByKey(req.Key)
@@ -149,7 +149,7 @@ func (c *CustomFieldsManager) RemoveCustomFieldDef(req *types.RemoveCustomFieldD
 		return body
 	}
 
-	entitiesFieldRemove(*field)
+	entitiesFieldRemove(ctx, *field)
 
 	c.Field = append(c.Field[:i], c.Field[i+1:]...)
 
@@ -157,7 +157,7 @@ func (c *CustomFieldsManager) RemoveCustomFieldDef(req *types.RemoveCustomFieldD
 	return body
 }
 
-func (c *CustomFieldsManager) RenameCustomFieldDef(req *types.RenameCustomFieldDef) soap.HasFault {
+func (c *CustomFieldsManager) RenameCustomFieldDef(ctx *Context, req *types.RenameCustomFieldDef) soap.HasFault {
 	body := &methods.RenameCustomFieldDefBody{}
 
 	_, field := c.findByKey(req.Key)
@@ -168,7 +168,7 @@ func (c *CustomFieldsManager) RenameCustomFieldDef(req *types.RenameCustomFieldD
 
 	field.Name = req.Name
 
-	entitiesFieldRename(*field)
+	entitiesFieldRename(ctx, *field)
 
 	body.Res = &types.RenameCustomFieldDefResponse{}
 	return body

--- a/simulator/datacenter.go
+++ b/simulator/datacenter.go
@@ -50,8 +50,8 @@ func NewDatacenter(ctx *Context, f *mo.Folder) *Datacenter {
 	return dc
 }
 
-func (dc *Datacenter) RenameTask(r *types.Rename_Task) soap.HasFault {
-	return RenameTask(dc, r)
+func (dc *Datacenter) RenameTask(ctx *Context, r *types.Rename_Task) soap.HasFault {
+	return RenameTask(ctx, dc, r)
 }
 
 // Create Datacenter Folders.
@@ -155,7 +155,7 @@ func (dc *Datacenter) PowerOnMultiVMTask(ctx *Context, req *types.PowerOnMultiVM
 
 		for _, ref := range req.Vm {
 			vm := Map.Get(ref).(*VirtualMachine)
-			Map.WithLock(vm, func() {
+			ctx.WithLock(vm, func() {
 				vm.PowerOnVMTask(ctx, &types.PowerOnVM_Task{})
 			})
 		}
@@ -165,7 +165,7 @@ func (dc *Datacenter) PowerOnMultiVMTask(ctx *Context, req *types.PowerOnMultiVM
 
 	return &methods.PowerOnMultiVM_TaskBody{
 		Res: &types.PowerOnMultiVM_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
@@ -192,7 +192,7 @@ func (d *Datacenter) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.Has
 
 	return &methods.Destroy_TaskBody{
 		Res: &types.Destroy_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/simulator/datastore.go
+++ b/simulator/datastore.go
@@ -93,9 +93,9 @@ func (ds *Datastore) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.Has
 
 		for _, mount := range ds.Host {
 			host := Map.Get(mount.Key).(*HostSystem)
-			Map.RemoveReference(host, &host.Datastore, ds.Self)
+			Map.RemoveReference(ctx, host, &host.Datastore, ds.Self)
 			parent := hostParent(&host.HostSystem)
-			Map.RemoveReference(parent, &parent.Datastore, ds.Self)
+			Map.RemoveReference(ctx, parent, &parent.Datastore, ds.Self)
 		}
 
 		p, _ := asFolderMO(Map.Get(*ds.Parent))
@@ -106,7 +106,7 @@ func (ds *Datastore) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.Has
 
 	return &methods.Destroy_TaskBody{
 		Res: &types.Destroy_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/simulator/dvs.go
+++ b/simulator/dvs.go
@@ -132,7 +132,7 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.Add
 				pg.Host = append(pg.Host, h)
 
 				host := Map.Get(h).(*HostSystem)
-				Map.AppendReference(host, &host.Network, pg.Reference())
+				Map.AppendReference(ctx, host, &host.Network, pg.Reference())
 
 				parent := Map.Get(*host.HostSystem.Parent)
 				computeNetworks := append(hostParent(&host.HostSystem).Network, pg.Reference())
@@ -152,12 +152,12 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(ctx *Context, c *types.Add
 
 	return &methods.AddDVPortgroup_TaskBody{
 		Res: &types.AddDVPortgroup_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
-func (s *DistributedVirtualSwitch) ReconfigureDvsTask(req *types.ReconfigureDvs_Task) soap.HasFault {
+func (s *DistributedVirtualSwitch) ReconfigureDvsTask(ctx *Context, req *types.ReconfigureDvs_Task) soap.HasFault {
 	task := CreateTask(s, "reconfigureDvs", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		spec := req.Spec.GetDVSConfigSpec()
 
@@ -229,7 +229,7 @@ func (s *DistributedVirtualSwitch) ReconfigureDvsTask(req *types.ReconfigureDvs_
 
 	return &methods.ReconfigureDvs_TaskBody{
 		Res: &types.ReconfigureDvs_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
@@ -251,7 +251,7 @@ func (s *DistributedVirtualSwitch) DestroyTask(ctx *Context, req *types.Destroy_
 
 	return &methods.Destroy_TaskBody{
 		Res: &types.Destroy_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/simulator/entity.go
+++ b/simulator/entity.go
@@ -23,7 +23,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-func RenameTask(e mo.Entity, r *types.Rename_Task) soap.HasFault {
+func RenameTask(ctx *Context, e mo.Entity, r *types.Rename_Task) soap.HasFault {
 	task := CreateTask(e, "rename", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		obj := Map.Get(r.This).(mo.Entity).Entity()
 
@@ -40,7 +40,7 @@ func RenameTask(e mo.Entity, r *types.Rename_Task) soap.HasFault {
 
 	return &methods.Rename_TaskBody{
 		Res: &types.Rename_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/simulator/entity_test.go
+++ b/simulator/entity_test.go
@@ -43,7 +43,7 @@ func TestRename(t *testing.T) {
 
 	f1 := Map.Get(vmFolder.ChildEntity[0]).(*Folder) // "F1"
 
-	id := vmFolder.CreateFolder(internalContext, &types.CreateFolder{
+	id := vmFolder.CreateFolder(SpoofContext(), &types.CreateFolder{
 		This: vmFolder.Reference(),
 		Name: "F2",
 	}).(*methods.CreateFolderBody).Res.Returnval
@@ -54,12 +54,13 @@ func TestRename(t *testing.T) {
 	name := f1.Name
 
 	for _, expect := range states {
-		id = f2.RenameTask(&types.Rename_Task{
+		id = f2.RenameTask(SpoofContext(), &types.Rename_Task{
 			This:    f2.Reference(),
 			NewName: name,
 		}).(*methods.Rename_TaskBody).Res.Returnval
 
 		task := Map.Get(id).(*Task)
+		task.wait()
 
 		if task.Info.State != expect {
 			t.Errorf("state=%s", task.Info.State)

--- a/simulator/event_manager.go
+++ b/simulator/event_manager.go
@@ -475,7 +475,7 @@ func (c *EventHistoryCollector) ReadPreviousEvents(ctx *Context, req *types.Read
 }
 
 func (c *EventHistoryCollector) DestroyCollector(ctx *Context, req *types.DestroyCollector) soap.HasFault {
-	ctx.Session.Remove(req.This)
+	ctx.Session.Remove(ctx, req.This)
 
 	ctx.WithLock(c.m, func() {
 		delete(c.m.collectors, req.This)

--- a/simulator/example_extend_test.go
+++ b/simulator/example_extend_test.go
@@ -35,14 +35,14 @@ type BusyVM struct {
 }
 
 // Override simulator.VirtualMachine.PowerOffVMTask to inject faults
-func (vm *BusyVM) PowerOffVMTask(req *types.PowerOffVM_Task) soap.HasFault {
+func (vm *BusyVM) PowerOffVMTask(ctx *simulator.Context, req *types.PowerOffVM_Task) soap.HasFault {
 	task := simulator.CreateTask(req.This, "powerOff", func(*simulator.Task) (types.AnyType, types.BaseMethodFault) {
 		return nil, &types.TaskInProgress{}
 	})
 
 	return &methods.PowerOffVM_TaskBody{
 		Res: &types.PowerOffVM_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/simulator/example_test.go
+++ b/simulator/example_test.go
@@ -151,8 +151,8 @@ func ExampleFolder_AddOpaqueNetwork() {
 			OpaqueNetworkType: "nsx.LogicalSwitch",
 		}
 
-		// Add NSX backed OpaqueNetwork, calling the simulator.Folder method directly
-		err = folder.AddOpaqueNetwork(spec)
+		// Add NSX backed OpaqueNetwork, calling the simulator.Folder method directly.
+		err = folder.AddOpaqueNetwork(simulator.SpoofContext(), spec)
 		if err != nil {
 			return err
 		}

--- a/simulator/file_manager.go
+++ b/simulator/file_manager.go
@@ -126,14 +126,14 @@ func (f *FileManager) deleteDatastoreFile(req *types.DeleteDatastoreFile_Task) t
 	return nil
 }
 
-func (f *FileManager) DeleteDatastoreFileTask(req *types.DeleteDatastoreFile_Task) soap.HasFault {
+func (f *FileManager) DeleteDatastoreFileTask(ctx *Context, req *types.DeleteDatastoreFile_Task) soap.HasFault {
 	task := CreateTask(f, "deleteDatastoreFile", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		return nil, f.deleteDatastoreFile(req)
 	})
 
 	return &methods.DeleteDatastoreFile_TaskBody{
 		Res: &types.DeleteDatastoreFile_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
@@ -190,14 +190,14 @@ func (f *FileManager) moveDatastoreFile(req *types.MoveDatastoreFile_Task) types
 	return nil
 }
 
-func (f *FileManager) MoveDatastoreFileTask(req *types.MoveDatastoreFile_Task) soap.HasFault {
+func (f *FileManager) MoveDatastoreFileTask(ctx *Context, req *types.MoveDatastoreFile_Task) soap.HasFault {
 	task := CreateTask(f, "moveDatastoreFile", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		return nil, f.moveDatastoreFile(req)
 	})
 
 	return &methods.MoveDatastoreFile_TaskBody{
 		Res: &types.MoveDatastoreFile_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
@@ -239,14 +239,14 @@ func (f *FileManager) copyDatastoreFile(req *types.CopyDatastoreFile_Task) types
 	return nil
 }
 
-func (f *FileManager) CopyDatastoreFileTask(req *types.CopyDatastoreFile_Task) soap.HasFault {
+func (f *FileManager) CopyDatastoreFileTask(ctx *Context, req *types.CopyDatastoreFile_Task) soap.HasFault {
 	task := CreateTask(f, "copyDatastoreFile", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		return nil, f.copyDatastoreFile(req)
 	})
 
 	return &methods.CopyDatastoreFile_TaskBody{
 		Res: &types.CopyDatastoreFile_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/simulator/folder.go
+++ b/simulator/folder.go
@@ -51,7 +51,7 @@ func folderEventArgument(f *mo.Folder) types.FolderEventArgument {
 }
 
 // update references when objects are added/removed from a Folder
-func folderUpdate(f *mo.Folder, o mo.Reference, u func(mo.Reference, *[]types.ManagedObjectReference, types.ManagedObjectReference)) {
+func folderUpdate(ctx *Context, f *mo.Folder, o mo.Reference, u func(*Context, mo.Reference, *[]types.ManagedObjectReference, types.ManagedObjectReference)) {
 	ref := o.Reference()
 
 	if f.Parent == nil {
@@ -67,9 +67,9 @@ func folderUpdate(f *mo.Folder, o mo.Reference, u func(mo.Reference, *[]types.Ma
 
 	switch ref.Type {
 	case "Network", "DistributedVirtualSwitch", "DistributedVirtualPortgroup":
-		u(dc, &dc.Network, ref)
+		u(ctx, dc, &dc.Network, ref)
 	case "Datastore":
-		u(dc, &dc.Datastore, ref)
+		u(ctx, dc, &dc.Datastore, ref)
 	}
 }
 
@@ -90,7 +90,7 @@ func folderPutChild(ctx *Context, f *mo.Folder, o mo.Entity) {
 		f.ChildEntity = append(f.ChildEntity, Map.reference(o))
 		Map.PutEntity(f, o)
 
-		folderUpdate(f, o, Map.AddReference)
+		folderUpdate(ctx, f, o, Map.AddReference)
 
 		ctx.WithLock(o, func() {
 			switch e := o.(type) {
@@ -106,12 +106,12 @@ func folderPutChild(ctx *Context, f *mo.Folder, o mo.Entity) {
 }
 
 func folderRemoveChild(ctx *Context, f *mo.Folder, o mo.Reference) {
-	Map.Remove(o.Reference())
+	Map.Remove(ctx, o.Reference())
 
 	ctx.WithLock(f, func() {
 		RemoveReference(&f.ChildEntity, o.Reference())
 
-		folderUpdate(f, o, Map.RemoveReference)
+		folderUpdate(ctx, f, o, Map.RemoveReference)
 	})
 }
 
@@ -130,7 +130,7 @@ func (f *Folder) typeNotSupported() *soap.Fault {
 
 // AddOpaqueNetwork adds an OpaqueNetwork type to the inventory, with default backing to that of an nsx.LogicalSwitch.
 // The vSphere API does not have a method to add this directly, so it must either be called directly or via Model.OpaqueNetwork setting.
-func (f *Folder) AddOpaqueNetwork(summary types.OpaqueNetworkSummary) error {
+func (f *Folder) AddOpaqueNetwork(ctx *Context, summary types.OpaqueNetworkSummary) error {
 	if !folderHasChildType(&f.Folder, "Network") {
 		return errors.New("not a network folder")
 	}
@@ -155,7 +155,7 @@ func (f *Folder) AddOpaqueNetwork(summary types.OpaqueNetworkSummary) error {
 	net.Network.Name = summary.Name
 	net.Summary = &summary
 
-	folderPutChild(internalContext, &f.Folder, net)
+	folderPutChild(ctx, &f.Folder, net)
 
 	return nil
 }
@@ -184,7 +184,7 @@ func (f *Folder) AddStandaloneHostTask(ctx *Context, a *types.AddStandaloneHost_
 
 	if folderHasChildType(&f.Folder, "ComputeResource") && folderHasChildType(&f.Folder, "Folder") {
 		r.Res = &types.AddStandaloneHost_TaskResponse{
-			Returnval: NewTask(&addStandaloneHost{f, ctx, a}).Run(),
+			Returnval: NewTask(&addStandaloneHost{f, ctx, a}).Run(ctx),
 		}
 	} else {
 		r.Fault_ = f.typeNotSupported()
@@ -262,10 +262,22 @@ func (f *Folder) CreateStoragePod(ctx *Context, c *types.CreateStoragePod) soap.
 }
 
 func (p *StoragePod) MoveIntoFolderTask(ctx *Context, c *types.MoveIntoFolder_Task) soap.HasFault {
-	f := &Folder{Folder: p.Folder}
-	res := f.MoveIntoFolderTask(ctx, c)
-	p.ChildEntity = append(p.ChildEntity, f.ChildEntity...)
-	return res
+	task := CreateTask(p, "moveIntoFolder", func(*Task) (types.AnyType, types.BaseMethodFault) {
+		f := &Folder{Folder: p.Folder}
+		id := f.MoveIntoFolderTask(ctx, c).(*methods.MoveIntoFolder_TaskBody).Res.Returnval
+		ftask := Map.Get(id).(*Task)
+		ftask.wait()
+		if ftask.Info.Error != nil {
+			return nil, ftask.Info.Error.Fault
+		}
+		p.ChildEntity = append(p.ChildEntity, f.ChildEntity...)
+		return nil, nil
+	})
+	return &methods.MoveIntoFolder_TaskBody{
+		Res: &types.MoveIntoFolder_TaskResponse{
+			Returnval: task.Run(ctx),
+		},
+	}
 }
 
 func (f *Folder) CreateDatacenter(ctx *Context, c *types.CreateDatacenter) soap.HasFault {
@@ -355,7 +367,7 @@ func (c *createVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 		pool := Map.Get(c.req.Pool).(mo.Entity)
 		cr := Map.getEntityComputeResource(pool)
 
-		Map.WithLock(cr, func() {
+		c.ctx.WithLock(cr, func() {
 			var hosts []types.ManagedObjectReference
 			switch cr := cr.(type) {
 			case *mo.ComputeResource:
@@ -384,19 +396,19 @@ func (c *createVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 	vm.Summary.Config.VmPathName = vm.Config.Files.VmPathName
 	vm.Summary.Runtime.Host = vm.Runtime.Host
 
-	err = vm.create(&c.req.Config, c.register)
+	err = vm.create(c.ctx, &c.req.Config, c.register)
 	if err != nil {
 		folderRemoveChild(c.ctx, &c.Folder.Folder, vm)
 		return nil, err
 	}
 
 	host := Map.Get(*vm.Runtime.Host).(*HostSystem)
-	Map.AppendReference(host, &host.Vm, vm.Self)
+	Map.AppendReference(c.ctx, host, &host.Vm, vm.Self)
 	vm.EnvironmentBrowser = *hostParent(&host.HostSystem).EnvironmentBrowser
 
 	for i := range vm.Datastore {
 		ds := Map.Get(vm.Datastore[i]).(*Datastore)
-		Map.AppendReference(ds, &ds.Vm, vm.Self)
+		Map.AppendReference(c.ctx, ds, &ds.Vm, vm.Self)
 	}
 
 	pool := Map.Get(*vm.ResourcePool)
@@ -441,7 +453,7 @@ func (c *createVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 func (f *Folder) CreateVMTask(ctx *Context, c *types.CreateVM_Task) soap.HasFault {
 	return &methods.CreateVM_TaskBody{
 		Res: &types.CreateVM_TaskResponse{
-			Returnval: NewTask(&createVM{f, ctx, c, false}).Run(),
+			Returnval: NewTask(&createVM{f, ctx, c, false}).Run(ctx),
 		},
 	}
 }
@@ -512,7 +524,7 @@ func (c *registerVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 		},
 	})
 
-	create.Run()
+	create.RunBlocking(c.ctx)
 
 	if create.Info.Error != nil {
 		return nil, create.Info.Error.Fault
@@ -524,7 +536,7 @@ func (c *registerVM) Run(task *Task) (types.AnyType, types.BaseMethodFault) {
 func (f *Folder) RegisterVMTask(ctx *Context, c *types.RegisterVM_Task) soap.HasFault {
 	return &methods.RegisterVM_TaskBody{
 		Res: &types.RegisterVM_TaskResponse{
-			Returnval: NewTask(&registerVM{f, ctx, c}).Run(),
+			Returnval: NewTask(&registerVM{f, ctx, c}).Run(ctx),
 		},
 	}
 }
@@ -549,7 +561,7 @@ func (f *Folder) MoveIntoFolderTask(ctx *Context, c *types.MoveIntoFolder_Task) 
 
 	return &methods.MoveIntoFolder_TaskBody{
 		Res: &types.MoveIntoFolder_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
@@ -646,13 +658,13 @@ func (f *Folder) CreateDVSTask(ctx *Context, req *types.CreateDVS_Task) soap.Has
 
 	return &methods.CreateDVS_TaskBody{
 		Res: &types.CreateDVS_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
-func (f *Folder) RenameTask(r *types.Rename_Task) soap.HasFault {
-	return RenameTask(f, r)
+func (f *Folder) RenameTask(ctx *Context, r *types.Rename_Task) soap.HasFault {
+	return RenameTask(ctx, f, r)
 }
 
 func (f *Folder) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.HasFault {
@@ -670,12 +682,13 @@ func (f *Folder) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.HasFaul
 			}
 
 			var fault types.BaseMethodFault
-			Map.WithLock(obj, func() {
+			ctx.WithLock(obj, func() {
 				id := obj.DestroyTask(&types.Destroy_Task{
 					This: c,
 				}).(*methods.Destroy_TaskBody).Res.Returnval
 
 				t := Map.Get(id).(*Task)
+				t.wait()
 				if t.Info.Error != nil {
 					fault = t.Info.Error.Fault // For example, can't destroy a powered on VM
 				}
@@ -692,7 +705,7 @@ func (f *Folder) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.HasFaul
 
 	return &methods.Destroy_TaskBody{
 		Res: &types.Destroy_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/simulator/host_datastore_system.go
+++ b/simulator/host_datastore_system.go
@@ -81,7 +81,7 @@ func (dss *HostDatastoreSystem) add(ctx *Context, ds *Datastore) *soap.Fault {
 	dss.Datastore = append(dss.Datastore, ds.Self)
 	dss.Host.Datastore = dss.Datastore
 	parent := hostParent(dss.Host)
-	Map.AddReference(parent, &parent.Datastore, ds.Self)
+	Map.AddReference(ctx, parent, &parent.Datastore, ds.Self)
 
 	browser := &HostDatastoreBrowser{}
 	browser.Datastore = dss.Datastore

--- a/simulator/host_datastore_system_test.go
+++ b/simulator/host_datastore_system_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestHostDatastoreSystem(t *testing.T) {
-	s := New(NewServiceInstance(esx.ServiceContent, esx.RootFolder))
+	s := New(NewServiceInstance(SpoofContext(), esx.ServiceContent, esx.RootFolder))
 
 	ts := s.NewServer()
 	defer ts.Close()

--- a/simulator/host_network_system_test.go
+++ b/simulator/host_network_system_test.go
@@ -30,7 +30,7 @@ import (
 func TestHostNetworkSystem(t *testing.T) {
 	ctx := context.Background()
 
-	s := New(NewServiceInstance(esx.ServiceContent, esx.RootFolder))
+	s := New(NewServiceInstance(SpoofContext(), esx.ServiceContent, esx.RootFolder))
 
 	host := object.NewHostSystem(s.client, esx.HostSystem.Reference())
 

--- a/simulator/host_system.go
+++ b/simulator/host_system.go
@@ -237,12 +237,12 @@ func (h *HostSystem) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.Has
 
 	return &methods.Destroy_TaskBody{
 		Res: &types.Destroy_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
-func (h *HostSystem) EnterMaintenanceModeTask(spec *types.EnterMaintenanceMode_Task) soap.HasFault {
+func (h *HostSystem) EnterMaintenanceModeTask(ctx *Context, spec *types.EnterMaintenanceMode_Task) soap.HasFault {
 	task := CreateTask(h, "enterMaintenanceMode", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		h.Runtime.InMaintenanceMode = true
 		return nil, nil
@@ -250,12 +250,12 @@ func (h *HostSystem) EnterMaintenanceModeTask(spec *types.EnterMaintenanceMode_T
 
 	return &methods.EnterMaintenanceMode_TaskBody{
 		Res: &types.EnterMaintenanceMode_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
-func (h *HostSystem) ExitMaintenanceModeTask(spec *types.ExitMaintenanceMode_Task) soap.HasFault {
+func (h *HostSystem) ExitMaintenanceModeTask(ctx *Context, spec *types.ExitMaintenanceMode_Task) soap.HasFault {
 	task := CreateTask(h, "exitMaintenanceMode", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		h.Runtime.InMaintenanceMode = false
 		return nil, nil
@@ -263,7 +263,7 @@ func (h *HostSystem) ExitMaintenanceModeTask(spec *types.ExitMaintenanceMode_Tas
 
 	return &methods.ExitMaintenanceMode_TaskBody{
 		Res: &types.ExitMaintenanceMode_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/simulator/host_system_test.go
+++ b/simulator/host_system_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestDefaultESX(t *testing.T) {
-	s := New(NewServiceInstance(esx.ServiceContent, esx.RootFolder))
+	s := New(NewServiceInstance(SpoofContext(), esx.ServiceContent, esx.RootFolder))
 
 	ts := s.NewServer()
 	defer ts.Close()

--- a/simulator/http_nfc_lease.go
+++ b/simulator/http_nfc_lease.go
@@ -111,7 +111,7 @@ func NewHttpNfcLease(ctx *Context, entity types.ManagedObjectReference) *HttpNfc
 }
 
 func (l *HttpNfcLease) HttpNfcLeaseComplete(ctx *Context, req *types.HttpNfcLeaseComplete) soap.HasFault {
-	ctx.Session.Remove(req.This)
+	ctx.Session.Remove(ctx, req.This)
 	nfcLease.Delete(req.This)
 
 	return &methods.HttpNfcLeaseCompleteBody{
@@ -120,7 +120,7 @@ func (l *HttpNfcLease) HttpNfcLeaseComplete(ctx *Context, req *types.HttpNfcLeas
 }
 
 func (l *HttpNfcLease) HttpNfcLeaseAbort(ctx *Context, req *types.HttpNfcLeaseAbort) soap.HasFault {
-	ctx.Session.Remove(req.This)
+	ctx.Session.Remove(ctx, req.This)
 	nfcLease.Delete(req.This)
 
 	return &methods.HttpNfcLeaseAbortBody{

--- a/simulator/internal/object_lock.go
+++ b/simulator/internal/object_lock.go
@@ -1,0 +1,86 @@
+package internal
+
+import (
+	"fmt"
+	"sync"
+)
+
+// SharedLockingContext is used to identify when locks can be shared. In
+// practice, simulator code uses the simulator.Context for a requst, but in
+// principle this could be anything.
+type SharedLockingContext interface{}
+
+// ObjectLock implements a basic "reference-counted" mutex, where a single
+// SharedLockingContext can "share" the lock across code paths or child tasks.
+type ObjectLock struct {
+	lock sync.Locker
+
+	stateLock sync.Mutex
+	heldBy    SharedLockingContext
+	count     int64
+}
+
+// NewObjectLock creates a new ObjectLock. Pass new(sync.Mutex) if you don't
+// have a custom sync.Locker.
+func NewObjectLock(lock sync.Locker) *ObjectLock {
+	return &ObjectLock{
+		lock: lock,
+	}
+}
+
+// try returns true if the lock has been acquired; false otherwise
+func (l *ObjectLock) try(onBehalfOf SharedLockingContext) bool {
+	l.stateLock.Lock()
+	defer l.stateLock.Unlock()
+
+	if l.heldBy == onBehalfOf {
+		l.count = l.count + 1
+		return true
+	}
+
+	if l.heldBy == nil {
+		// we expect no contention for this lock (unless the object has a custom Locker)
+		l.lock.Lock()
+		l.count = 1
+		l.heldBy = onBehalfOf
+		return true
+	}
+
+	return false
+}
+
+// wait returns when there's a chance that try() might succeed.
+// It is intended to be better than busy-waiting or sleeping.
+func (l *ObjectLock) wait() {
+	l.lock.Lock()
+	l.lock.Unlock()
+}
+
+// Release decrements the reference count. The caller should pass their
+// context, which is used to sanity check that the Unlock() call is valid. If
+// this is the last reference to the lock for this SharedLockingContext, the lock
+// is Unlocked and can be acquired by another SharedLockingContext.
+func (l *ObjectLock) Release(onBehalfOf SharedLockingContext) {
+	l.stateLock.Lock()
+	defer l.stateLock.Unlock()
+	if l.heldBy != onBehalfOf {
+		panic(fmt.Sprintf("Attempt to unlock on behalf of %#v, but is held by %#v", onBehalfOf, l.heldBy))
+	}
+	l.count = l.count - 1
+	if l.count == 0 {
+		l.heldBy = nil
+		l.lock.Unlock()
+	}
+}
+
+// Acquire blocks until it can acquire the lock for onBehalfOf
+func (l *ObjectLock) Acquire(onBehalfOf SharedLockingContext) {
+	acquired := false
+	for !acquired {
+		if l.try(onBehalfOf) {
+			return
+		} else {
+			l.wait()
+		}
+	}
+}

--- a/simulator/model.go
+++ b/simulator/model.go
@@ -22,11 +22,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/vmware/govmomi"
@@ -307,7 +309,7 @@ func (m *Model) resolveReferences(ctx *Context) error {
 	if !ok {
 		// Need to have at least 1 Datacenter
 		root := Map.Get(Map.content().RootFolder).(*Folder)
-		ref := root.CreateDatacenter(internalContext, &types.CreateDatacenter{
+		ref := root.CreateDatacenter(ctx, &types.CreateDatacenter{
 			This: root.Self,
 			Name: "DC0",
 		}).(*methods.CreateDatacenterBody).Res.Returnval
@@ -381,9 +383,27 @@ func (m *Model) loadMethod(obj mo.Reference, dir string) error {
 	return nil
 }
 
+// When simulator code needs to call other simulator code, it typically passes whatever
+// context is associated with the request it's servicing.
+// Model code isn't servicing a request, but still needs a context, so we spoof
+// one for the purposes of calling simulator code.
+// Test code also tends to do this.
+func SpoofContext() *Context {
+	return &Context{
+		Context: context.Background(),
+		Session: &Session{
+			UserSession: types.UserSession{
+				Key: uuid.New().String(),
+			},
+			Registry: NewRegistry(),
+		},
+		Map: Map,
+	}
+}
+
 // Load Model from the given directory, as created by the 'govc object.save' command.
 func (m *Model) Load(dir string) error {
-	ctx := internalContext
+	ctx := SpoofContext()
 	var s *ServiceInstance
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -415,7 +435,7 @@ func (m *Model) Load(dir string) error {
 		}
 
 		if s == nil {
-			s = NewServiceInstance(m.ServiceContent, m.RootFolder)
+			s = NewServiceInstance(ctx, m.ServiceContent, m.RootFolder)
 		}
 
 		obj, err := loadObject(content)
@@ -443,8 +463,8 @@ func (m *Model) Load(dir string) error {
 
 // Create populates the Model with the given ModelConfig
 func (m *Model) Create() error {
-	ctx := internalContext
-	m.Service = New(NewServiceInstance(m.ServiceContent, m.RootFolder))
+	ctx := SpoofContext()
+	m.Service = New(NewServiceInstance(ctx, m.ServiceContent, m.RootFolder))
 
 	client := m.Service.client
 	root := object.NewRootFolder(client)
@@ -487,7 +507,8 @@ func (m *Model) Create() error {
 				}},
 			}
 
-			_, _ = dvs.Reconfigure(ctx, config)
+			task, _ = dvs.Reconfigure(ctx, config)
+			_, _ = task.WaitForResult(context.Background(), nil)
 		}
 
 		return host, nil
@@ -541,7 +562,8 @@ func (m *Model) Create() error {
 				vm := object.NewVirtualMachine(client, info.Result.(types.ManagedObjectReference))
 
 				if m.Autostart {
-					_, _ = vm.PowerOn(ctx)
+					task, _ = vm.PowerOn(ctx)
+					_, _ = task.WaitForResult(ctx, nil)
 				}
 			}
 
@@ -665,7 +687,7 @@ func (m *Model) Create() error {
 		for i := 0; i < m.OpaqueNetwork; i++ {
 			var summary types.OpaqueNetworkSummary
 			summary.Name = m.fmtName(dcName+"_NSX", i)
-			err := networkFolder.AddOpaqueNetwork(summary)
+			err := networkFolder.AddOpaqueNetwork(ctx, summary)
 			if err != nil {
 				return err
 			}
@@ -811,11 +833,13 @@ func (m *Model) createLocalDatastore(dc string, name string, hosts []*object.Hos
 // Remove cleans up items created by the Model, such as local datastore directories
 func (m *Model) Remove() {
 	// Remove associated vm containers, if any
+	Map.m.Lock()
 	for _, obj := range Map.objects {
 		if vm, ok := obj.(*VirtualMachine); ok {
 			vm.run.remove(vm)
 		}
 	}
+	Map.m.Unlock()
 
 	for _, dir := range m.dirs {
 		_ = os.RemoveAll(dir)
@@ -873,4 +897,22 @@ func Test(f func(context.Context, *vim25.Client), model ...*Model) {
 		f(ctx, c)
 		return nil
 	}, model...)
+}
+
+// delay sleeps according to DelayConfig. If no delay specified, returns immediately.
+func (dc *DelayConfig) delay(method string) {
+	d := 0
+	if dc.Delay > 0 {
+		d = dc.Delay
+	}
+	if md, ok := dc.MethodDelay[method]; ok {
+		d += md
+	}
+	if dc.DelayJitter > 0 {
+		d += int(rand.NormFloat64() * dc.DelayJitter * float64(d))
+	}
+	if d > 0 {
+		//fmt.Printf("Delaying method %s %d ms\n", method, d)
+		time.Sleep(time.Duration(d) * time.Millisecond)
+	}
 }

--- a/simulator/portgroup.go
+++ b/simulator/portgroup.go
@@ -27,7 +27,7 @@ type DistributedVirtualPortgroup struct {
 	mo.DistributedVirtualPortgroup
 }
 
-func (s *DistributedVirtualPortgroup) ReconfigureDVPortgroupTask(req *types.ReconfigureDVPortgroup_Task) soap.HasFault {
+func (s *DistributedVirtualPortgroup) ReconfigureDVPortgroupTask(ctx *Context, req *types.ReconfigureDVPortgroup_Task) soap.HasFault {
 	task := CreateTask(s, "reconfigureDvPortgroup", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		s.Config.DefaultPortConfig = req.Spec.DefaultPortConfig
 		s.Config.NumPorts = req.Spec.NumPorts
@@ -47,7 +47,7 @@ func (s *DistributedVirtualPortgroup) ReconfigureDVPortgroupTask(req *types.Reco
 
 	return &methods.ReconfigureDVPortgroup_TaskBody{
 		Res: &types.ReconfigureDVPortgroup_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
@@ -55,8 +55,8 @@ func (s *DistributedVirtualPortgroup) ReconfigureDVPortgroupTask(req *types.Reco
 func (s *DistributedVirtualPortgroup) DestroyTask(ctx *Context, req *types.Destroy_Task) soap.HasFault {
 	task := CreateTask(s, "destroy", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		vswitch := Map.Get(*s.Config.DistributedVirtualSwitch).(*DistributedVirtualSwitch)
-		Map.RemoveReference(vswitch, &vswitch.Portgroup, s.Reference())
-		Map.removeString(vswitch, &vswitch.Summary.PortgroupName, s.Name)
+		Map.RemoveReference(ctx, vswitch, &vswitch.Portgroup, s.Reference())
+		Map.removeString(ctx, vswitch, &vswitch.Summary.PortgroupName, s.Name)
 
 		f := Map.getEntityParent(vswitch, "Folder").(*Folder)
 		folderRemoveChild(ctx, &f.Folder, s.Reference())
@@ -66,7 +66,7 @@ func (s *DistributedVirtualPortgroup) DestroyTask(ctx *Context, req *types.Destr
 
 	return &methods.Destroy_TaskBody{
 		Res: &types.Destroy_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 

--- a/simulator/property_collector.go
+++ b/simulator/property_collector.go
@@ -485,8 +485,8 @@ func (pc *PropertyCollector) DestroyPropertyCollector(ctx *Context, c *types.Des
 		filter.DestroyPropertyFilter(ctx, &types.DestroyPropertyFilter{This: ref})
 	}
 
-	ctx.Session.Remove(c.This)
-	ctx.Map.Remove(c.This)
+	ctx.Session.Remove(ctx, c.This)
+	ctx.Map.Remove(ctx, c.This)
 
 	body.Res = &types.DestroyPropertyCollectorResponse{}
 
@@ -579,7 +579,7 @@ func (pc *PropertyCollector) UpdateObject(o mo.Reference, changes []types.Proper
 	})
 }
 
-func (pc *PropertyCollector) RemoveObject(ref types.ManagedObjectReference) {
+func (pc *PropertyCollector) RemoveObject(_ *Context, ref types.ManagedObjectReference) {
 	pc.update(types.ObjectUpdate{
 		Obj:       ref,
 		Kind:      types.ObjectUpdateKindLeave,
@@ -673,7 +673,7 @@ func (pc *PropertyCollector) WaitForUpdatesEx(ctx *Context, r *types.WaitForUpda
 		return body
 	}
 
-	ticker := time.NewTicker(250 * time.Millisecond) // allow for updates to accumulate
+	ticker := time.NewTicker(20 * time.Millisecond) // allow for updates to accumulate
 	defer ticker.Stop()
 	// Start the wait loop, returning on one of:
 	// - Client calls CancelWaitForUpdates

--- a/simulator/property_filter.go
+++ b/simulator/property_filter.go
@@ -38,7 +38,7 @@ func (f *PropertyFilter) DestroyPropertyFilter(ctx *Context, c *types.DestroyPro
 
 	RemoveReference(&f.pc.Filter, c.This)
 
-	ctx.Session.Remove(c.This)
+	ctx.Session.Remove(ctx, c.This)
 
 	body.Res = &types.DestroyPropertyFilterResponse{}
 

--- a/simulator/registry_test.go
+++ b/simulator/registry_test.go
@@ -38,7 +38,7 @@ func TestRegistry(t *testing.T) {
 		t.Fail()
 	}
 
-	r.Remove(ref)
+	r.Remove(SpoofContext(), ref)
 
 	if r.Get(ref) != nil {
 		t.Fail()

--- a/simulator/service_instance.go
+++ b/simulator/service_instance.go
@@ -32,7 +32,7 @@ type ServiceInstance struct {
 	mo.ServiceInstance
 }
 
-func NewServiceInstance(content types.ServiceContent, folder mo.Folder) *ServiceInstance {
+func NewServiceInstance(ctx *Context, content types.ServiceContent, folder mo.Folder) *ServiceInstance {
 	Map = NewRegistry()
 
 	s := &ServiceInstance{}
@@ -46,7 +46,7 @@ func NewServiceInstance(content types.ServiceContent, folder mo.Folder) *Service
 	Map.Put(f)
 
 	if content.About.ApiType == "HostAgent" {
-		CreateDefaultESX(internalContext, f)
+		CreateDefaultESX(ctx, f)
 	} else {
 		content.About.InstanceUuid = uuid.New().String()
 	}

--- a/simulator/session_manager_test.go
+++ b/simulator/session_manager_test.go
@@ -236,7 +236,7 @@ func TestSessionManagerAuth(t *testing.T) {
 func TestSessionManagerLoginExtension(t *testing.T) {
 	ctx := context.Background()
 
-	s := New(NewServiceInstance(vpx.ServiceContent, vpx.RootFolder))
+	s := New(NewServiceInstance(SpoofContext(), vpx.ServiceContent, vpx.RootFolder))
 	s.TLS = new(tls.Config)
 	ts := s.NewServer()
 	defer ts.Close()

--- a/simulator/snapshot.go
+++ b/simulator/snapshot.go
@@ -114,7 +114,7 @@ func (v *VirtualMachineSnapshot) RemoveSnapshotTask(ctx *Context, req *types.Rem
 		var changes []types.PropertyChange
 
 		vm := Map.Get(v.Vm).(*VirtualMachine)
-		Map.WithLock(vm, func() {
+		ctx.WithLock(vm, func() {
 			if vm.Snapshot.CurrentSnapshot != nil && *vm.Snapshot.CurrentSnapshot == req.This {
 				parent := findParentSnapshotInTree(vm.Snapshot.RootSnapshotList, req.This)
 				changes = append(changes, types.PropertyChange{Name: "snapshot.currentSnapshot", Val: parent})
@@ -134,23 +134,23 @@ func (v *VirtualMachineSnapshot) RemoveSnapshotTask(ctx *Context, req *types.Rem
 			Map.Update(vm, changes)
 		})
 
-		Map.Remove(req.This)
+		Map.Remove(ctx, req.This)
 
 		return nil, nil
 	})
 
 	return &methods.RemoveSnapshot_TaskBody{
 		Res: &types.RemoveSnapshot_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
-func (v *VirtualMachineSnapshot) RevertToSnapshotTask(req *types.RevertToSnapshot_Task) soap.HasFault {
+func (v *VirtualMachineSnapshot) RevertToSnapshotTask(ctx *Context, req *types.RevertToSnapshot_Task) soap.HasFault {
 	task := CreateTask(v.Vm, "revertToSnapshot", func(t *Task) (types.AnyType, types.BaseMethodFault) {
 		vm := Map.Get(v.Vm).(*VirtualMachine)
 
-		Map.WithLock(vm, func() {
+		ctx.WithLock(vm, func() {
 			Map.Update(vm, []types.PropertyChange{
 				{Name: "snapshot.currentSnapshot", Val: v.Self},
 			})
@@ -161,7 +161,7 @@ func (v *VirtualMachineSnapshot) RevertToSnapshotTask(req *types.RevertToSnapsho
 
 	return &methods.RevertToSnapshot_TaskBody{
 		Res: &types.RevertToSnapshot_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/simulator/storage_resource_manager.go
+++ b/simulator/storage_resource_manager.go
@@ -31,7 +31,7 @@ type StorageResourceManager struct {
 	mo.StorageResourceManager
 }
 
-func (m *StorageResourceManager) ConfigureStorageDrsForPodTask(req *types.ConfigureStorageDrsForPod_Task) soap.HasFault {
+func (m *StorageResourceManager) ConfigureStorageDrsForPodTask(ctx *Context, req *types.ConfigureStorageDrsForPod_Task) soap.HasFault {
 	task := CreateTask(m, "configureStorageDrsForPod", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		cluster := Map.Get(req.Pod).(*StoragePod)
 
@@ -51,7 +51,7 @@ func (m *StorageResourceManager) ConfigureStorageDrsForPodTask(req *types.Config
 
 	return &methods.ConfigureStorageDrsForPod_TaskBody{
 		Res: &types.ConfigureStorageDrsForPod_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/simulator/task.go
+++ b/simulator/task.go
@@ -29,9 +29,16 @@ import (
 const vTaskSuffix = "_Task" // vmomi suffix
 const sTaskSuffix = "Task"  // simulator suffix (avoiding golint warning)
 
+// TaskDelay applies to all tasks.
+// Names for DelayConfig.MethodDelay will differ for task and api delays. API
+// level names often look like PowerOff_Task, whereas the task name is simply
+// PowerOff.
+var TaskDelay = DelayConfig{}
+
 type Task struct {
 	mo.Task
 
+	ctx     *Context
 	Execute func(*Task) (types.AnyType, types.BaseMethodFault)
 }
 
@@ -77,33 +84,83 @@ type TaskRunner interface {
 	Run(*Task) (types.AnyType, types.BaseMethodFault)
 }
 
-func (t *Task) Run() types.ManagedObjectReference {
-	now := time.Now()
+// taskReference is a helper struct so we can call AcquireLock in Run()
+type taskReference struct {
+	ref types.ManagedObjectReference
+}
 
-	Map.Update(t, []types.PropertyChange{
-		{Name: "info.startTime", Val: now},
+func (tr *taskReference) Reference() types.ManagedObjectReference {
+	return tr.ref
+}
+
+func (t *Task) Run(ctx *Context) types.ManagedObjectReference {
+	t.ctx = ctx
+	Map.AtomicUpdate(t.ctx, t, []types.PropertyChange{
+		{Name: "info.startTime", Val: time.Now()},
 		{Name: "info.state", Val: types.TaskInfoStateRunning},
 	})
 
-	res, err := t.Execute(t)
-	state := types.TaskInfoStateSuccess
-	var fault interface{}
-	if err != nil {
-		state = types.TaskInfoStateError
-		fault = types.LocalizedMethodFault{
-			Fault:            err,
-			LocalizedMessage: fmt.Sprintf("%T", err),
-		}
+	tr := &taskReference{
+		ref: *t.Info.Entity,
 	}
+	// in most cases, the caller already holds this lock, and we would like
+	// the lock to be held across the "hand off" to the async goroutine.
+	unlock := Map.AcquireLock(ctx, tr)
 
-	now = time.Now()
+	go func() {
+		TaskDelay.delay(t.Info.Name)
+		res, err := t.Execute(t)
+		unlock()
 
-	Map.Update(t, []types.PropertyChange{
-		{Name: "info.completeTime", Val: now},
-		{Name: "info.state", Val: state},
-		{Name: "info.result", Val: res},
-		{Name: "info.error", Val: fault},
-	})
+		state := types.TaskInfoStateSuccess
+		var fault interface{}
+		if err != nil {
+			state = types.TaskInfoStateError
+			fault = types.LocalizedMethodFault{
+				Fault:            err,
+				LocalizedMessage: fmt.Sprintf("%T", err),
+			}
+		}
+
+		Map.AtomicUpdate(t.ctx, t, []types.PropertyChange{
+			{Name: "info.completeTime", Val: time.Now()},
+			{Name: "info.state", Val: state},
+			{Name: "info.result", Val: res},
+			{Name: "info.error", Val: fault},
+		})
+	}()
 
 	return t.Self
+}
+
+// RunBlocking() should only be used when an async simulator task needs to wait
+// on another async simulator task.
+// It polls for task completion to avoid the need to set up a PropertyCollector.
+func (t *Task) RunBlocking(ctx *Context) {
+	_ = t.Run(ctx)
+	t.wait()
+}
+
+func (t *Task) wait() {
+	// we do NOT want to share our lock with the tasks's context, because
+	// the goroutine that executes the task will use ctx to update the
+	// state (among other things).
+	isolatedLockingContext := &Context{}
+
+	isRunning := func() bool {
+		var running bool
+		Map.WithLock(isolatedLockingContext, t, func() {
+			switch t.Info.State {
+			case types.TaskInfoStateSuccess, types.TaskInfoStateError:
+				running = false
+			default:
+				running = true
+			}
+		})
+		return running
+	}
+
+	for isRunning() {
+		time.Sleep(10 * time.Millisecond)
+	}
 }

--- a/simulator/task_manager.go
+++ b/simulator/task_manager.go
@@ -59,6 +59,6 @@ func (m *TaskManager) PutObject(obj mo.Reference) {
 	m.Unlock()
 }
 
-func (*TaskManager) RemoveObject(types.ManagedObjectReference) {}
+func (*TaskManager) RemoveObject(*Context, types.ManagedObjectReference) {}
 
 func (*TaskManager) UpdateObject(mo.Reference, []types.PropertyChange) {}

--- a/simulator/task_test.go
+++ b/simulator/task_test.go
@@ -49,7 +49,7 @@ func TestNewTask(t *testing.T) {
 		t.Errorf("descriptionId=%s", info.DescriptionId)
 	}
 
-	task.Run()
+	task.RunBlocking(SpoofContext())
 
 	if info.State != types.TaskInfoStateSuccess {
 		t.Fail()
@@ -57,7 +57,8 @@ func TestNewTask(t *testing.T) {
 
 	add.fault = &types.ManagedObjectNotFound{}
 
-	task.Run()
+	task.Run(SpoofContext())
+	task.wait()
 
 	if info.State != types.TaskInfoStateError {
 		t.Fail()

--- a/simulator/user_directory_test.go
+++ b/simulator/user_directory_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestUserDirectory(t *testing.T) {
-	s := New(NewServiceInstance(esx.ServiceContent, esx.RootFolder))
+	s := New(NewServiceInstance(SpoofContext(), esx.ServiceContent, esx.RootFolder))
 
 	ts := s.NewServer()
 	defer ts.Close()
@@ -92,7 +92,7 @@ func TestUserDirectory(t *testing.T) {
 }
 
 func TestUserDirectoryExactlyMatch(t *testing.T) {
-	s := New(NewServiceInstance(esx.ServiceContent, esx.RootFolder))
+	s := New(NewServiceInstance(SpoofContext(), esx.ServiceContent, esx.RootFolder))
 
 	ts := s.NewServer()
 	defer ts.Close()

--- a/simulator/view_manager.go
+++ b/simulator/view_manager.go
@@ -130,7 +130,7 @@ type ContainerView struct {
 
 func (v *ContainerView) DestroyView(ctx *Context, c *types.DestroyView) soap.HasFault {
 	ctx.Map.RemoveHandler(v)
-	ctx.Session.Remove(c.This)
+	ctx.Session.Remove(ctx, c.This)
 	return destroyView(c.This)
 }
 
@@ -215,8 +215,8 @@ func (v *ContainerView) PutObject(obj mo.Reference) {
 	}
 }
 
-func (v *ContainerView) RemoveObject(obj types.ManagedObjectReference) {
-	Map.RemoveReference(v, &v.View, obj)
+func (v *ContainerView) RemoveObject(ctx *Context, obj types.ManagedObjectReference) {
+	Map.RemoveReference(ctx, v, &v.View, obj)
 }
 
 func (*ContainerView) UpdateObject(mo.Reference, []types.PropertyChange) {}
@@ -259,7 +259,7 @@ func (v *ListView) add(refs []types.ManagedObjectReference) *types.ManagedObject
 }
 
 func (v *ListView) DestroyView(ctx *Context, c *types.DestroyView) soap.HasFault {
-	ctx.Session.Remove(c.This)
+	ctx.Session.Remove(ctx, c.This)
 	return destroyView(c.This)
 }
 

--- a/simulator/virtual_disk_manager.go
+++ b/simulator/virtual_disk_manager.go
@@ -81,7 +81,7 @@ func vdmCreateVirtualDisk(op types.VirtualDeviceConfigSpecFileOperation, req *ty
 	return nil
 }
 
-func (m *VirtualDiskManager) CreateVirtualDiskTask(_ *Context, req *types.CreateVirtualDisk_Task) soap.HasFault {
+func (m *VirtualDiskManager) CreateVirtualDiskTask(ctx *Context, req *types.CreateVirtualDisk_Task) soap.HasFault {
 	task := CreateTask(m, "createVirtualDisk", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		if err := vdmCreateVirtualDisk(types.VirtualDeviceConfigSpecFileOperationCreate, req); err != nil {
 			return "", err
@@ -91,12 +91,12 @@ func (m *VirtualDiskManager) CreateVirtualDiskTask(_ *Context, req *types.Create
 
 	return &methods.CreateVirtualDisk_TaskBody{
 		Res: &types.CreateVirtualDisk_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
-func (m *VirtualDiskManager) DeleteVirtualDiskTask(_ *Context, req *types.DeleteVirtualDisk_Task) soap.HasFault {
+func (m *VirtualDiskManager) DeleteVirtualDiskTask(ctx *Context, req *types.DeleteVirtualDisk_Task) soap.HasFault {
 	task := CreateTask(m, "deleteVirtualDisk", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		fm := Map.FileManager()
 
@@ -116,12 +116,12 @@ func (m *VirtualDiskManager) DeleteVirtualDiskTask(_ *Context, req *types.Delete
 
 	return &methods.DeleteVirtualDisk_TaskBody{
 		Res: &types.DeleteVirtualDisk_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
-func (m *VirtualDiskManager) MoveVirtualDiskTask(_ *Context, req *types.MoveVirtualDisk_Task) soap.HasFault {
+func (m *VirtualDiskManager) MoveVirtualDiskTask(ctx *Context, req *types.MoveVirtualDisk_Task) soap.HasFault {
 	task := CreateTask(m, "moveVirtualDisk", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		fm := Map.FileManager()
 
@@ -146,12 +146,12 @@ func (m *VirtualDiskManager) MoveVirtualDiskTask(_ *Context, req *types.MoveVirt
 
 	return &methods.MoveVirtualDisk_TaskBody{
 		Res: &types.MoveVirtualDisk_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
-func (m *VirtualDiskManager) CopyVirtualDiskTask(_ *Context, req *types.CopyVirtualDisk_Task) soap.HasFault {
+func (m *VirtualDiskManager) CopyVirtualDiskTask(ctx *Context, req *types.CopyVirtualDisk_Task) soap.HasFault {
 	task := CreateTask(m, "copyVirtualDisk", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		if req.DestSpec != nil {
 			if Map.IsVPX() {
@@ -182,7 +182,7 @@ func (m *VirtualDiskManager) CopyVirtualDiskTask(_ *Context, req *types.CopyVirt
 
 	return &methods.CopyVirtualDisk_TaskBody{
 		Res: &types.CopyVirtualDisk_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/simulator/virtual_machine_test.go
+++ b/simulator/virtual_machine_test.go
@@ -1144,8 +1144,14 @@ func TestVmRefreshStorageInfo(t *testing.T) {
 		t.Errorf("expected %d, got %d", fileLayoutExCount+1, len(vmm.LayoutEx.File))
 	}
 
-	_ = f.Close()
-	_ = os.Remove(f.Name())
+	err = f.Close()
+	if err != nil {
+		t.Fatalf("f.Close failure: %v", err)
+	}
+	err = os.Remove(f.Name())
+	if err != nil {
+		t.Fatalf("os.Remove(%s) failure: %v", f.Name(), err)
+	}
 
 	if err = vm.RefreshStorageInfo(ctx); err != nil {
 		t.Error(err)

--- a/simulator/vstorage_object_manager.go
+++ b/simulator/vstorage_object_manager.go
@@ -128,7 +128,7 @@ func (m *VcenterVStorageObjectManager) ReconcileDatastoreInventoryTask(ctx *Cont
 
 	return &methods.ReconcileDatastoreInventory_TaskBody{
 		Res: &types.ReconcileDatastoreInventory_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
@@ -267,19 +267,19 @@ func (m *VcenterVStorageObjectManager) createObject(req *types.CreateDisk_Task, 
 
 }
 
-func (m *VcenterVStorageObjectManager) CreateDiskTask(req *types.CreateDisk_Task) soap.HasFault {
+func (m *VcenterVStorageObjectManager) CreateDiskTask(ctx *Context, req *types.CreateDisk_Task) soap.HasFault {
 	task := CreateTask(m, "createDisk", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		return m.createObject(req, false)
 	})
 
 	return &methods.CreateDisk_TaskBody{
 		Res: &types.CreateDisk_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
-func (m *VcenterVStorageObjectManager) DeleteVStorageObjectTask(req *types.DeleteVStorageObject_Task) soap.HasFault {
+func (m *VcenterVStorageObjectManager) DeleteVStorageObjectTask(ctx *Context, req *types.DeleteVStorageObject_Task) soap.HasFault {
 	task := CreateTask(m, "deleteDisk", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		obj := m.object(req.Datastore, req.Id)
 		if obj == nil {
@@ -290,7 +290,7 @@ func (m *VcenterVStorageObjectManager) DeleteVStorageObjectTask(req *types.Delet
 		ds := Map.Get(req.Datastore).(*Datastore)
 		dc := Map.getEntityDatacenter(ds)
 		dm := Map.VirtualDiskManager()
-		dm.DeleteVirtualDiskTask(internalContext, &types.DeleteVirtualDisk_Task{
+		dm.DeleteVirtualDiskTask(ctx, &types.DeleteVirtualDisk_Task{
 			Name:       backing.FilePath,
 			Datacenter: &dc.Self,
 		})
@@ -302,7 +302,7 @@ func (m *VcenterVStorageObjectManager) DeleteVStorageObjectTask(req *types.Delet
 
 	return &methods.DeleteVStorageObject_TaskBody{
 		Res: &types.DeleteVStorageObject_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
@@ -322,7 +322,7 @@ func (m *VcenterVStorageObjectManager) RetrieveSnapshotInfo(req *types.RetrieveS
 	return body
 }
 
-func (m *VcenterVStorageObjectManager) VStorageObjectCreateSnapshotTask(req *types.VStorageObjectCreateSnapshot_Task) soap.HasFault {
+func (m *VcenterVStorageObjectManager) VStorageObjectCreateSnapshotTask(ctx *Context, req *types.VStorageObjectCreateSnapshot_Task) soap.HasFault {
 	task := CreateTask(m, "createSnapshot", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		obj := m.object(req.Datastore, req.Id)
 		if obj == nil {
@@ -344,12 +344,12 @@ func (m *VcenterVStorageObjectManager) VStorageObjectCreateSnapshotTask(req *typ
 
 	return &methods.VStorageObjectCreateSnapshot_TaskBody{
 		Res: &types.VStorageObjectCreateSnapshot_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }
 
-func (m *VcenterVStorageObjectManager) DeleteSnapshotTask(req *types.DeleteSnapshot_Task) soap.HasFault {
+func (m *VcenterVStorageObjectManager) DeleteSnapshotTask(ctx *Context, req *types.DeleteSnapshot_Task) soap.HasFault {
 	task := CreateTask(m, "deleteSnapshot", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		obj := m.object(req.Datastore, req.Id)
 		if obj != nil {
@@ -365,7 +365,7 @@ func (m *VcenterVStorageObjectManager) DeleteSnapshotTask(req *types.DeleteSnaps
 
 	return &methods.DeleteSnapshot_TaskBody{
 		Res: &types.DeleteSnapshot_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }

--- a/vcsim/README.md
+++ b/vcsim/README.md
@@ -52,6 +52,10 @@ Usage of vcsim:
 
 [model]:https://godoc.org/github.com/vmware/govmomi/simulator#Model
 
+### Version Information
+
+To print detailed (build) information for vcsim run: `vcsim version`. 
+
 ## Examples
 
 The following examples illustrate how **vcsim** flags can be used to change the

--- a/vcsim/main.go
+++ b/vcsim/main.go
@@ -49,6 +49,12 @@ import (
 	_ "github.com/vmware/govmomi/vsan/simulator"
 )
 
+var (
+	buildVersion string
+	buildCommit  string
+	buildDate    string
+)
+
 func main() {
 	model := simulator.VPX()
 
@@ -107,7 +113,12 @@ func main() {
 	switch flag.Arg(0) {
 	case "uuidgen": // util-linux not installed on Travis CI
 		fmt.Println(uuid.New().String())
-		return
+		os.Exit(0)
+	case "version":
+		fmt.Fprintf(flag.CommandLine.Output(), "Build Version: %s\n", buildVersion)
+		fmt.Fprintf(flag.CommandLine.Output(), "Build Commit: %s\n", buildCommit)
+		fmt.Fprintf(flag.CommandLine.Output(), "Build Date: %s\n", buildDate)
+		os.Exit(0)
 	}
 
 	if methodDelay != "" {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,14 +1,21 @@
 # github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d
+## explicit
 github.com/a8m/tree
 # github.com/davecgh/go-xdr v0.0.0-20161123171359-e6a2ba005892 => github.com/rasky/go-xdr v0.0.0-20170217172119-4930550ba2e2
+## explicit
 github.com/davecgh/go-xdr/xdr2
 # github.com/google/uuid v0.0.0-20170306145142-6a5e28554805
+## explicit
 github.com/google/uuid
 # github.com/kr/pretty v0.1.0 => github.com/dougm/pretty v0.0.0-20171025230240-2ee9d7453c02
+## explicit
 github.com/kr/pretty
 # github.com/kr/text v0.1.0
+## explicit
 github.com/kr/text
 # github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728
+## explicit
 github.com/vmware/vmw-guestinfo/bdoor
 github.com/vmware/vmw-guestinfo/message
 github.com/vmware/vmw-guestinfo/vmcheck
+# github.com/davecgh/go-xdr => github.com/rasky/go-xdr v0.0.0-20170217172119-4930550ba2e2

--- a/vsan/simulator/simulator.go
+++ b/vsan/simulator/simulator.go
@@ -57,7 +57,7 @@ func (s *StretchedClusterSystem) VSANVcConvertToStretchedCluster(ctx *simulator.
 
 	return &methods.VSANVcConvertToStretchedClusterBody{
 		Res: &types.VSANVcConvertToStretchedClusterResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(ctx),
 		},
 	}
 }


### PR DESCRIPTION
First PR towards fully automating the release process with `goreleaser`.
Cutting a release is still done manually, but using the goreleaser
configuration provided in this PR. Once we gain confidence in the
associated Github Actions workflows we can finally switch towards full
release automation. This PR also adds more tests and build verification.

⚠️ **BREAKING** Release artefacts created by the provided `goreleaser`
configuration use a different naming template. In addition, the `386`
`GOARCH` is dropped. Example for `vcsim`:

```bash
vcsim_v0.25.0_freebsd_armv6.tar.gz
vcsim_v0.25.0_linux_armv6.tar.gz
vcsim_v0.25.0_darwin_arm64.tar.gz
vcsim_v0.25.0_freebsd_arm64.tar.gz
vcsim_v0.25.0_linux_arm64.tar.gz
vcsim_v0.25.0_darwin_x86_64.tar.gz
vcsim_v0.25.0_linux_mips64le.tar.gz
vcsim_v0.25.0_linux_x86_64.tar.gz
vcsim_v0.25.0_windows_x86_64.zip
vcsim_v0.25.0_freebsd_x86_64.tar.gz
```

Homebrew files will be created during a manual release but not yet
pushed to the pre-configured `govmomi/homebrew-tap`. This will be fixed
in a subsequent PR when switching to full release automation. The
Homebrew community provides `govc` in the core repo (not validated by
govmomi maintainers though).

Docker images (separate for `govc` and `vcsim`) for `linux/amd64` will
be created and pushed during a manual run. Example tags pushed for
`govc`:

```bash
vmware/govc:6a3ba216
vmware/govc:latest
vmware/govc:v0.25.0
```

⚠️ **BREAKING** The checksum file is renamed to `checksums.txt`.

The go modules version is bumped to use `v1.14`
[semantics](https://golang.org/doc/modules/gomod-ref#go). The go tool
will use vendoring by default. For explicitness and documentation
purposes `-mod=vendor` is still passed in various build/test related
workflows.

⚠️ **BREAKING** `govc version` output changed (enhanced) to include build
related information (injected via `goreleaser`). Example:

```bash
govc  version
Build Version: v0.25.0
Build Commit: 6a3ba216
Build Date: 2021-04-04T19:00:11Z
```

Since some tests and customers might depend on the old behavior, a new
flag `govc version -short` is introduced (and fixed in adjusted tests):

```bash
govc 0.25.0
```

`vcsim` shows version in the flag help section:

```bash
./vcsim -h
Usage of vcsim:
  -E string
Output vcsim variables to the given fifo or stdout (default
"-")
[snip...]

Build Version: 0.25.0
Build Commit: 09d8402d568975c232d60c76e140bfe70ee5e7a0
Build Date: 2021-04-01T12:01:20Z
```

Add `make govc-test` Makefile target in the tests workflow.

Verify build/releasability by running a new workflow on every
PR/push to master and as a daily cron job which mimics a
`goreleaser` run (without pushing a release, artefacts, etc.).

Fix wording in the stale issue/PR workflow.

Use a custom `powercli` image in `bats` tests to avoid Docker
rate limit pulls:
`projects.registry.vmware.com/pez/powerclicore`.

Instead of using a `curl` container, use `curl` provided as
part of the runner to avoid rate limits/reduce time.

Closes: #2339
Related: #2302 #1844 #2295

Signed-off-by: Michael Gasch <mgasch@vmware.com>